### PR TITLE
Fix #22 to add pooling support

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -54,6 +54,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-jms-spi-deployment</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-netty-deployment</artifactId>
     </dependency>
     <!-- Needed because quarkus-netty[-deployment] needs it present if netty-codec-http 

--- a/runtime/src/main/java/org/amqphub/quarkus/qpid/jms/runtime/ConnectionFactoryWrapper.java
+++ b/runtime/src/main/java/org/amqphub/quarkus/qpid/jms/runtime/ConnectionFactoryWrapper.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.amqphub.quarkus.qpid.jms.runtime;
+
+import jakarta.jms.ConnectionFactory;
+
+public interface ConnectionFactoryWrapper {
+    ConnectionFactory wrap(ConnectionFactory connectionFactory);
+}

--- a/runtime/src/main/java/org/amqphub/quarkus/qpid/jms/runtime/QpidJmsProducer.java
+++ b/runtime/src/main/java/org/amqphub/quarkus/qpid/jms/runtime/QpidJmsProducer.java
@@ -15,6 +15,7 @@
 */
 package org.amqphub.quarkus.qpid.jms.runtime;
 
+import io.quarkus.arc.Arc;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Inject;
@@ -34,7 +35,14 @@ public class QpidJmsProducer {
     @ApplicationScoped
     @DefaultBean
     public ConnectionFactory connectionFactory() {
-        return new JmsConnectionFactory(config.username.orElse(null), config.password.orElse(null), config.url);
+        ConnectionFactory connectionFactory = new JmsConnectionFactory(config.username.orElse(null), config.password.orElse(null), config.url);
+        ConnectionFactoryWrapper wrapper = Arc.container().instance(ConnectionFactoryWrapper.class).get();
+
+        if (config.wrap && wrapper != null) {
+            return wrapper.wrap(connectionFactory);
+        } else {
+            return connectionFactory;
+        }
     }
 
     public QpidJmsRuntimeConfig getConfig() {

--- a/runtime/src/main/java/org/amqphub/quarkus/qpid/jms/runtime/QpidJmsRecorder.java
+++ b/runtime/src/main/java/org/amqphub/quarkus/qpid/jms/runtime/QpidJmsRecorder.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.amqphub.quarkus.qpid.jms.runtime;
+
+import io.quarkus.runtime.RuntimeValue;
+import io.quarkus.runtime.annotations.Recorder;
+import jakarta.jms.ConnectionFactory;
+
+import java.util.function.Function;
+
+@Recorder
+public class QpidJmsRecorder {
+    public RuntimeValue<ConnectionFactoryWrapper> getConnectionFactoryWrapper(Function<ConnectionFactory, Object> wrapper) {
+        return new RuntimeValue<>(connectionFactory -> (ConnectionFactory) wrapper.apply(connectionFactory));
+    }
+}

--- a/runtime/src/main/java/org/amqphub/quarkus/qpid/jms/runtime/QpidJmsRuntimeConfig.java
+++ b/runtime/src/main/java/org/amqphub/quarkus/qpid/jms/runtime/QpidJmsRuntimeConfig.java
@@ -43,4 +43,11 @@ public class QpidJmsRuntimeConfig {
      */
     @ConfigItem
     public Optional<String> password;
+
+    /**
+     * Whether to wrap a ConnectionFactory by ConnectionFactoryWrapper which could be introduced by other extensions,
+     * such as quarkus-pooled-jms to provide pooling capability
+     */
+    @ConfigItem(defaultValue = "false")
+    public boolean wrap;
 }


### PR DESCRIPTION
With these changes, `quarkus-qpid-jms` could leverage the pooling capability provided by [quarkus-pooled-jms](https://github.com/quarkiverse/quarkus-pooled-jms) by combineing these two extensions simply.